### PR TITLE
Don't quote builddir value

### DIFF
--- a/io.github.wereturtle.ghostwriter.json
+++ b/io.github.wereturtle.ghostwriter.json
@@ -100,7 +100,7 @@
         {
             "name": "ghostwriter",
             "buildsystem": "qmake",
-            "builddir": "true",
+            "builddir": true,
             "sources": [
                 {
                     "type": "git",


### PR DESCRIPTION
It produces the following warning and doesn't work:
`(flatpak-builder:39771): Json-WARNING **: Failed to deserialize "builddir" property of type "gboolean" for an object of type "BuilderModule"`